### PR TITLE
Add proper amount of leading zeros when printing decimals

### DIFF
--- a/test/modules/TokenBalanceTracker.sol
+++ b/test/modules/TokenBalanceTracker.sol
@@ -154,7 +154,7 @@ contract TokenBalanceTracker {
     function toStringWithDecimals(uint256 _number, uint8 decimals) internal pure returns(string memory){
         uint256 integerToPrint = _number / (10**decimals);
         uint256 decimalsToPrint = _number - (_number / (10**decimals)) * (10**decimals);
-        return string.concat(integerToPrint.toString(), '.', decimalsToPrint.toString());
+        return string.concat(integerToPrint.toString(), '.', addLeadingZeros(decimalsToPrint, decimals));
     }
 
     function updateBalanceTracker(address _user) internal {
@@ -180,6 +180,36 @@ contract TokenBalanceTracker {
             } 
             tokenBalances = memBalances;    
         }
+    }
+
+    function addLeadingZeros(uint256 value, uint256 desiredLength) public pure returns (string memory) {
+        // Use your existing toString function
+        string memory str = value.toString();
+        uint256 currentLength = bytes(str).length;
+
+        // If the string is already at or exceeding the desired length, return it as is
+        if (currentLength >= desiredLength) {
+            return str;
+        }
+
+        // Calculate how many zeros to add
+        uint256 zerosToAdd = desiredLength - currentLength;
+
+        // Add leading zeros
+        bytes memory result = new bytes(desiredLength);
+        bytes memory strBytes = bytes(str);
+
+        // Add leading zeros
+        for (uint256 i = 0; i < zerosToAdd; i++) {
+            result[i] = bytes1("0");
+        }
+
+        // Copy the original string after the zeros
+        for (uint256 i = 0; i < currentLength; i++) {
+            result[zerosToAdd + i] = strBytes[i];
+        }
+
+        return string(result);
     }
 
     function calculateBalanceDelta(address _user) internal view returns(BalanceDeltaReturn memory nativeDelta, BalanceDeltaReturn[] memory tokenDeltas){


### PR DESCRIPTION
An issue in the `toStringWithDecimals` function caused the `TokenBalanceTracker` to display incorrect values by failing to account for leading zeroes. As a result, decimal values were misrepresented—e.g., a decimal value of `10` was logged as `.10` instead of `.010` when using three decimal places.

To verify the fix, I ran the following test:

```sh
forge test --match-contract Exploit_FourMeme -vvv
```

### Results:

**Before the fix:**
```solidity
  snowWBNBPool before swap
  Native Tokens: 0.000000000000000000
  # For a memDeltas[i].value = 1476
  snowboard: 0.1 (-0.1476)
  # For a memDeltas[i].value = 94079959113755941
  Wrapped BNB: 23.425920040311988407 (-0.94079959113755941)
```

**After the fix:**
```solidity
  snowWBNBPool before swap
  Native Tokens: 0.000000000000000000
  # For a memDeltas[i].value = 1476
  snowboard: 0.000000000000000001 (-0.000000000000001476) 
  # For a memDeltas[i].value = 94079959113755941
  Wrapped BNB: 23.425920040311988407 (-0.094079959113755941) 
```

The correction ensures that values are properly formatted with leading zeroes, preserving the intended precision.